### PR TITLE
Fix dacite.Config forward_references overriding get_type_hints()'s default globalns.

### DIFF
--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
 
     name: Python ${{ matrix.python-version }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 dist/
 *.egg-info/
 build/
+/venv/
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .pytest_cache/
+.mypy_cache/
 *.pyc
 dist/
 *.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 script:
 - pytest --cov=dacite
 - black --check .
-- mypy dacite
+- mypy
 - pylint dacite
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 dist: xenial
 language: python
 python:
-- 3.6
 - 3.7
 - 3.8
-- 3.9-dev
+- 3.9
+- 3.10
+- 3.11
 install:
 - pip install -e .[dev]
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add explicit `__all__` configuration
+- Support [PEP 604] unions through `types.UnionType`
+
+[PEP 604]: https://peps.python.org/pep-0604/
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0b1] - 2022-11-28
+
 ### Added
 
 - Add explicit `__all__` configuration
-- Support [PEP 604] unions through `types.UnionType`
+- Support [PEP 604] unions through `types.UnionType` #184
+- numpy.typing.NDArray dataclass members #156
+- Add `allow_missing_fields_as_none` option for missing fields #199
+- Ability to customize `from_dict` per dataclass #122
+- more general type hint for `type_hooks` #120
+- Add Generic Hook Types #83
+- Add stricter mypy type check flags #76
 
 [PEP 604]: https://peps.python.org/pep-0604/
 
 ### Fixed
 
 - Do not suppress `KeyError` in a type hook
+- `from_dict` in case of frozen dataclass with non-init default #196
+- empty tuple used for Sequence type #175
+- Type_hooks not applied to InitVar fields #172
+- extract_optional for Optional of Union. #164
+- change Data from Dict to Mapping #159
+- Fix encoding of PKG-INFO file #86
 
 ## [1.6.0] - 2020-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - extract_optional for Optional of Union. #164
 - change Data from Dict to Mapping #159
 - Fix encoding of PKG-INFO file #86
+- `Config` forward_references overriding `get_type_hints()`'s default `globalns`
 
 ## [1.6.0] - 2020-11-30
 

--- a/README.md
+++ b/README.md
@@ -235,8 +235,7 @@ assert result == B(a_list=[A(x='test1', y=1), A(x='test2', y=2)])
 
 You can use `Config.type_hooks` argument if you want to transform the input 
 data of a data class field with given type into the new value. You have to 
-pass a following mapping: `{Type: callable}`, where `callable` is a 
-`Callable[[Any], Any]`.
+pass a mapping of type `Mapping[Type, Callable[[Any], Any]`.
 
 ```python
 @dataclass

--- a/README.md
+++ b/README.md
@@ -258,6 +258,56 @@ If a data class field type is a `Optional[T]` you can pass both -
 collections, e.g. when a field has type `List[T]` you can use `List[T]` to 
 transform whole collection or `T` to transform each item. 
 
+To target all types use `Any`.  Targeting collections without their sub-types
+will target all collections of those types, such as `List` and `Dict`. 
+
+```python
+@dataclass
+class ShoppingCart:
+    store: str
+    item_ids: List[int]
+
+data = {
+    'store': '7-Eleven',
+    'item_ids': [1, 2, 3],
+}
+
+def print_value(value):
+    print(value)
+    return value
+
+def print_collection(collection):
+    for item in collection:
+        print(item)
+    return collection
+
+result = from_dict(
+    data_class=ShoppingCart, 
+    data=data, 
+    config=Config(
+        type_hooks={
+            Any: print_value, 
+            List: print_collection
+        }
+    )
+)
+```
+
+prints
+
+```
+7-Eleven
+[1, 2, 3]
+1
+2
+3
+```
+
+If a data class field type is a `Optional[T]` you can pass both - 
+`Optional[T]` or just `T` - as a key in `type_hooks`. The same with generic 
+collections, e.g. when a field has type `List[T]` you can use `List[T]` to 
+transform whole collection or `T` to transform each item. 
+
 ### Casting
 
 It's a very common case that you want to create an instance of a field type 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ pip install dacite
 
 ## Requirements
 
-Minimum Python version supported by `dacite` is 3.6.
+Minimum Python version supported by `dacite` is 3.7.
 
 ## Quick start
 

--- a/dacite/config.py
+++ b/dacite/config.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field
-from typing import Dict, Any, Callable, Optional, Type, List
+from typing import Dict, Any, Callable, Optional, Type, List, Union
 
 
 @dataclass
 class Config:
-    type_hooks: Dict[Type, Callable[[Any], Any]] = field(default_factory=dict)
+    type_hooks: Dict[Union[Type, object], Callable[[Any], Any]] = field(default_factory=dict)
     cast: List[Type] = field(default_factory=list)
     forward_references: Optional[Dict[str, Any]] = None
     check_types: bool = True

--- a/dacite/config.py
+++ b/dacite/config.py
@@ -10,3 +10,4 @@ class Config:
     check_types: bool = True
     strict: bool = False
     strict_unions_match: bool = False
+    allow_missing_fields_as_none: bool = False

--- a/dacite/config.py
+++ b/dacite/config.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field
-from typing import Dict, Any, Callable, Optional, Type, List, Union
+from typing import Dict, Any, Callable, Optional, Type, List, Union, Mapping
 
 
 @dataclass
 class Config:
-    type_hooks: Dict[Union[Type, object], Callable[[Any], Any]] = field(default_factory=dict)
+    type_hooks: Mapping[Union[Type, object], Callable[[Any], Any]] = field(default_factory=dict)
     cast: List[Type] = field(default_factory=list)
     forward_references: Optional[Dict[str, Any]] = None
     check_types: bool = True

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -1,7 +1,7 @@
 import copy
 from dataclasses import is_dataclass
 from itertools import zip_longest
-from typing import TypeVar, Type, Optional, get_type_hints, Mapping, Any
+from typing import TypeVar, Type, Optional, Mapping, Any
 
 from dacite.config import Config
 from dacite.data import Data
@@ -27,6 +27,7 @@ from dacite.types import (
     is_init_var,
     extract_init_var,
     is_set,
+    get_data_class_hints,
 )
 
 T = TypeVar("T")
@@ -44,7 +45,7 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
     post_init_values: Data = {}
     config = config or Config()
     try:
-        data_class_hints = get_type_hints(data_class, globalns=config.forward_references)
+        data_class_hints = get_data_class_hints(data_class, globalns=config.forward_references)
     except NameError as error:
         raise ForwardReferenceError(str(error))
     data_class_fields = get_fields(data_class)

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -67,12 +67,14 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
                 raise
             if config.check_types and not is_instance(value, field.type):
                 raise WrongTypeError(field_path=field.name, field_type=field.type, value=value)
+        elif not field.init:
+            # If the non-init field isn't in the dict, let the dataclass handle default, to ensure
+            # we won't get errors in the case of frozen dataclasses, as issue #195 highlights.
+            continue
         else:
             try:
                 value = get_default_value_for_field(field)
             except DefaultValueNotFoundError:
-                if not field.init:
-                    continue
                 raise MissingValueError(field.name)
         if field.init:
             init_values[field.name] = value

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -142,6 +142,8 @@ def _build_value_for_collection(collection: Type, data: Any, config: Config) -> 
         item_type = extract_generic(collection, defaults=(Any, Any))[1]
         return data_type((key, _build_value(type_=item_type, data=value, config=config)) for key, value in data.items())
     elif is_instance(data, tuple):
+        if not data:
+            return data_type()
         types = extract_generic(collection)
         if len(types) == 2 and types[1] == Ellipsis:
             return data_type(_build_value(type_=types[0], data=item, config=config) for item in data)

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -74,7 +74,9 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
             continue
         else:
             try:
-                value = get_default_value_for_field(field)
+                value = get_default_value_for_field(
+                    field, allow_missing_fields_as_none=config.allow_missing_fields_as_none
+                )
             except DefaultValueNotFoundError:
                 raise MissingValueError(field.name)
         if field.init:

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -4,7 +4,7 @@ from itertools import zip_longest
 from typing import TypeVar, Type, Optional, Mapping, Any
 
 from dacite.config import Config
-from dacite.data import Data
+from dacite.data import Data, DictData
 from dacite.dataclasses import get_default_value_for_field, create_instance, DefaultValueNotFoundError, get_fields
 from dacite.exceptions import (
     ForwardReferenceError,
@@ -41,8 +41,8 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
     :param config: a configuration of the creation process
     :return: an instance of a data class
     """
-    init_values: Data = {}
-    post_init_values: Data = {}
+    init_values: DictData = {}
+    post_init_values: DictData = {}
     config = config or Config()
     try:
         data_class_hints = get_data_class_hints(data_class, globalns=config.forward_references)

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -98,6 +98,8 @@ def _build_value(type_: Type, data: Any, config: Config) -> Any:
                 _build_value(type_=extract_generic(type_)[0], data=single_val, config=config) for single_val in data
             )
     elif is_dataclass(type_) and is_instance(data, Data):
+        if hasattr(type_, "from_dict"):
+            return type_.from_dict(data=data, config=config)
         return from_dict(data_class=type_, data=data, config=config)
     return data
 

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -45,7 +45,7 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
     post_init_values: DictData = {}
     config = config or Config()
     try:
-        data_class_hints = get_data_class_hints(data_class, globalns=config.forward_references)
+        data_class_hints = get_data_class_hints(data_class, localns=config.forward_references)
     except NameError as error:
         raise ForwardReferenceError(str(error))
     data_class_fields = get_fields(data_class)

--- a/dacite/data.py
+++ b/dacite/data.py
@@ -1,3 +1,3 @@
-from typing import Dict, Any
+from typing import Mapping, Any
 
-Data = Dict[str, Any]
+Data = Mapping[str, Any]

--- a/dacite/data.py
+++ b/dacite/data.py
@@ -1,3 +1,4 @@
-from typing import Mapping, Any
+from typing import Dict, Mapping, Any
 
 Data = Mapping[str, Any]
+DictData = Dict[str, Any]

--- a/dacite/dataclasses.py
+++ b/dacite/dataclasses.py
@@ -22,7 +22,7 @@ def get_default_value_for_field(field: Field, allow_missing_fields_as_none: bool
 
 
 def create_instance(data_class: Type[T], init_values: Data, post_init_values: Data) -> T:
-    instance = data_class(**init_values)
+    instance: T = data_class(**init_values)
     for key, value in post_init_values.items():
         setattr(instance, key, value)
     return instance

--- a/dacite/dataclasses.py
+++ b/dacite/dataclasses.py
@@ -11,12 +11,12 @@ class DefaultValueNotFoundError(Exception):
     pass
 
 
-def get_default_value_for_field(field: Field) -> Any:
+def get_default_value_for_field(field: Field, allow_missing_fields_as_none: bool = False) -> Any:
     if field.default != MISSING:
         return field.default
     elif field.default_factory != MISSING:  # type: ignore
         return field.default_factory()  # type: ignore
-    elif is_optional(field.type):
+    elif is_optional(field.type) or allow_missing_fields_as_none:
         return None
     raise DefaultValueNotFoundError()
 

--- a/dacite/dataclasses.py
+++ b/dacite/dataclasses.py
@@ -14,8 +14,8 @@ class DefaultValueNotFoundError(Exception):
 def get_default_value_for_field(field: Field, allow_missing_fields_as_none: bool = False) -> Any:
     if field.default != MISSING:
         return field.default
-    elif field.default_factory != MISSING:  # type: ignore
-        return field.default_factory()  # type: ignore
+    elif field.default_factory != MISSING:
+        return field.default_factory()
     elif is_optional(field.type) or allow_missing_fields_as_none:
         return None
     raise DefaultValueNotFoundError()

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -104,6 +104,10 @@ def is_union(type_: Type) -> bool:
         return False
 
 
+def is_tuple(type_: Type) -> bool:
+    return is_subclass(type_, Tuple)
+
+
 def is_literal(type_: Type) -> bool:
     try:
         from typing import Literal  # type: ignore
@@ -147,7 +151,7 @@ def is_instance(value: Any, type_: Type) -> bool:
             return False
         if not extract_generic(type_):
             return True
-        if isinstance(value, tuple):
+        if isinstance(value, tuple) and is_tuple(type_):
             tuple_types = extract_generic(type_)
             if len(tuple_types) == 1 and tuple_types[0] == ():
                 return len(value) == 0

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -5,7 +5,7 @@ T = TypeVar("T", bound=Any)
 
 
 def transform_value(
-    type_hooks: Dict[Union[Type, object], Callable[[Any], Any]], cast: List[Type], target_type: Type, value: Any
+    type_hooks: Mapping[Union[Type, object], Callable[[Any], Any]], cast: List[Type], target_type: Type, value: Any
 ) -> Any:
     # Generic hook type match
     if Any in type_hooks:

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -148,7 +148,7 @@ def is_instance(value: Any, type_: Type) -> bool:
         origin = extract_origin_collection(type_)
         if not isinstance(value, origin):
             return False
-        if not extract_generic(type_):
+        if extract_generic_no_defaults(type_) is None:
             return True
         if isinstance(value, tuple) and is_tuple(type_):
             tuple_types = extract_generic(type_)
@@ -209,6 +209,15 @@ def extract_generic(type_: Type, defaults: Tuple = ()) -> tuple:
         return type_.__args__ or defaults
     except AttributeError:
         return defaults
+
+
+def extract_generic_no_defaults(type_: Type) -> Union[tuple, None]:
+    try:
+        if hasattr(type_, "_special") and type_._special:
+            return None
+        return type_.__args__
+    except AttributeError:
+        return None
 
 
 def is_subclass(sub_type: Type, base_type: Type) -> bool:

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -52,10 +52,11 @@ def is_optional(type_: Type) -> bool:
 
 
 def extract_optional(optional: Type[Optional[T]]) -> T:
-    for type_ in extract_generic(optional):
-        if type_ is not type(None):
-            return type_
-    raise ValueError("can not find not-none value")
+    other_members = [member for member in extract_generic(optional) if member is not type(None)]
+    if other_members:
+        return Union[tuple(other_members)]
+    else:
+        raise ValueError("can not find not-none value")
 
 
 def is_generic(type_: Type) -> bool:

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -1,5 +1,5 @@
 from dataclasses import InitVar
-from typing import Type, Any, Optional, Union, Collection, TypeVar, Dict, Callable, Mapping, List, Tuple
+from typing import Type, Any, Optional, Union, Collection, TypeVar, Dict, Callable, Mapping, List, Tuple, get_type_hints
 
 T = TypeVar("T", bound=Any)
 
@@ -38,6 +38,14 @@ def transform_value(
         item_cls = extract_generic(target_type, defaults=(Any,))[0]
         return collection_cls(transform_value(type_hooks, cast, item_cls, item) for item in value)
     return value
+
+
+def get_data_class_hints(data_class: Type[T], globalns: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    type_hints = get_type_hints(data_class, globalns=globalns)
+    for attr, type_hint in type_hints.items():
+        if is_init_var(type_hint):
+            type_hints[attr] = extract_init_var(type_hint)
+    return type_hints
 
 
 def extract_origin_collection(collection: Type) -> Type:

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -63,7 +63,15 @@ def is_generic(type_: Type) -> bool:
 
 
 def is_union(type_: Type) -> bool:
-    return is_generic(type_) and type_.__origin__ == Union
+    if is_generic(type_) and type_.__origin__ == Union:
+        return True
+
+    try:
+        from types import UnionType  # type: ignore
+
+        return isinstance(type_, UnionType)
+    except ImportError:
+        return False
 
 
 def is_literal(type_: Type) -> bool:

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -5,11 +5,20 @@ T = TypeVar("T", bound=Any)
 
 
 def transform_value(
-    type_hooks: Dict[Type, Callable[[Any], Any]], cast: List[Type], target_type: Type, value: Any
+    type_hooks: Dict[Union[Type, object], Callable[[Any], Any]], cast: List[Type], target_type: Type, value: Any
 ) -> Any:
+    # Generic hook type match
+    if Any in type_hooks:
+        value = type_hooks[Any](value)
+    if is_generic_collection(target_type):
+        collection_type = extract_origin_type(target_type)
+        if collection_type and collection_type in type_hooks:
+            value = type_hooks[collection_type](value)
+    # Exact hook type match
     if target_type in type_hooks:
         value = type_hooks[target_type](value)
     else:
+        # Cast to types in cast list
         for cast_type in cast:
             if is_subclass(target_type, cast_type):
                 if is_generic_collection(target_type):
@@ -20,11 +29,13 @@ def transform_value(
                 else:
                     value = target_type(value)
                 break
+    # Peel optional types
     if is_optional(target_type):
         if value is None:
             return None
         target_type = extract_optional(target_type)
         return transform_value(type_hooks, cast, target_type, value)
+    # For collections (dict/list), transform each item
     if is_generic_collection(target_type) and isinstance(value, extract_origin_collection(target_type)):
         collection_cls = value.__class__
         if issubclass(collection_cls, dict):
@@ -53,6 +64,16 @@ def extract_origin_collection(collection: Type) -> Type:
         return collection.__extra__
     except AttributeError:
         return collection.__origin__
+
+
+
+def extract_origin_type(collection: Type) -> Optional[Type]:
+    collection_type = extract_origin_collection(collection)
+    if collection_type is list:
+        return List
+    elif collection_type is dict:
+        return Dict
+    return None
 
 
 def is_optional(type_: Type) -> bool:

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -66,7 +66,6 @@ def extract_origin_collection(collection: Type) -> Type:
         return collection.__origin__
 
 
-
 def extract_origin_type(collection: Type) -> Optional[Type]:
     collection_type = extract_origin_collection(collection)
     if collection_type is list:
@@ -83,7 +82,7 @@ def is_optional(type_: Type) -> bool:
 def extract_optional(optional: Type[Optional[T]]) -> T:
     other_members = [member for member in extract_generic(optional) if member is not type(None)]
     if other_members:
-        return Union[tuple(other_members)]
+        return Union[tuple(other_members)]  # type: ignore
     else:
         raise ValueError("can not find not-none value")
 
@@ -105,7 +104,7 @@ def is_union(type_: Type) -> bool:
 
 
 def is_tuple(type_: Type) -> bool:
-    return is_subclass(type_, Tuple)
+    return is_subclass(type_, tuple)
 
 
 def is_literal(type_: Type) -> bool:
@@ -200,7 +199,7 @@ def extract_generic(type_: Type, defaults: Tuple = ()) -> tuple:
     try:
         if hasattr(type_, "_special") and type_._special:
             return defaults
-        return type_.__args__ or defaults  # type: ignore
+        return type_.__args__ or defaults
     except AttributeError:
         return defaults
 

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -175,6 +175,9 @@ def is_instance(value: Any, type_: Type) -> bool:
         return is_instance(value, extract_init_var(type_))
     elif is_type_generic(type_):
         return is_subclass(value, extract_generic(type_)[0])
+    elif is_generic(type_):
+        origin = extract_origin_collection(type_)
+        return isinstance(value, origin)
     else:
         try:
             # As described in PEP 484 - section: "The numeric tower"
@@ -190,9 +193,13 @@ def is_generic_collection(type_: Type) -> bool:
         return False
     origin = extract_origin_collection(type_)
     try:
-        return bool(origin and issubclass(origin, Collection))
+        return bool(origin and issubclass(origin, Collection) and not skip_generic_conversion(origin))
     except (TypeError, AttributeError):
         return False
+
+
+def skip_generic_conversion(origin: Type) -> bool:
+    return origin.__module__ == "numpy" and origin.__qualname__ == "ndarray"
 
 
 def extract_generic(type_: Type, defaults: Tuple = ()) -> tuple:

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -51,8 +51,8 @@ def transform_value(
     return value
 
 
-def get_data_class_hints(data_class: Type[T], globalns: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    type_hints = get_type_hints(data_class, globalns=globalns)
+def get_data_class_hints(data_class: Type[T], localns: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    type_hints = get_type_hints(data_class, localns=localns)
     for attr, type_hint in type_hints.items():
         if is_init_var(type_hint):
             type_hints[attr] = extract_init_var(type_hint)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,22 @@
+[mypy]
+python_version = 3.6
+files = dacite
+show_error_codes = True
+pretty = True
+
+no_implicit_reexport = True
+no_implicit_optional = True
+strict_equality = True
+strict_optional = True
+check_untyped_defs = True
+disallow_incomplete_defs = True
+ignore_missing_imports = False
+
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unreachable = True
+
+[mypy-dacite.types]
+warn_return_any = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 files = dacite
 show_error_codes = True
 pretty = True

--- a/setup.py
+++ b/setup.py
@@ -16,17 +16,17 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     keywords="dataclasses",
     packages=["dacite"],
     package_data={"dacite": ["py.typed"]},
-    install_requires=['dataclasses;python_version<"3.7"'],
     extras_require={
         "dev": [
             "pytest>=5",
@@ -35,7 +35,7 @@ setup(
             "black",
             "mypy",
             "pylint",
-            'numpy>=1.21.0;python_version>="3.7"',
+            "numpy>=1.21.0",
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="dacite",
     version="1.6.0",
     description="Simple creation of data classes from dictionaries.",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="Konrad Hałas",
     author_email="halas.konrad@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,15 @@ setup(
     packages=["dacite"],
     package_data={"dacite": ["py.typed"]},
     install_requires=['dataclasses;python_version<"3.7"'],
-    extras_require={"dev": ["pytest>=5", "pytest-cov", "coveralls", "black", "mypy", "pylint"]},
+    extras_require={
+        "dev": [
+            "pytest>=5",
+            "pytest-cov",
+            "coveralls",
+            "black",
+            "mypy",
+            "pylint",
+            'numpy>=1.21.0;python_version>="3.7"',
+        ]
+    },
 )

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,4 +3,5 @@ import sys
 import pytest
 
 literal_support = init_var_type_support = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires Python 3.8")
+type_hints_with_generic_collections_support = pytest.mark.skipif(sys.version_info < (3, 9), reason="requires Python 3.9")
 pep_604_support = pytest.mark.skipif(sys.version_info < (3, 10), reason="requires Python 3.10")

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 
+ndarray_support = pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python 3.7")
 literal_support = init_var_type_support = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires Python 3.8")
 type_hints_with_generic_collections_support = pytest.mark.skipif(
     sys.version_info < (3, 9), reason="requires Python 3.9"

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,5 +3,7 @@ import sys
 import pytest
 
 literal_support = init_var_type_support = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires Python 3.8")
-type_hints_with_generic_collections_support = pytest.mark.skipif(sys.version_info < (3, 9), reason="requires Python 3.9")
+type_hints_with_generic_collections_support = pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="requires Python 3.9"
+)
 pep_604_support = pytest.mark.skipif(sys.version_info < (3, 10), reason="requires Python 3.10")

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,3 +3,4 @@ import sys
 import pytest
 
 literal_support = init_var_type_support = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires Python 3.8")
+pep_604_support = pytest.mark.skipif(sys.version_info < (3, 10), reason="requires Python 3.10")

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Set, Union, Dict, Collection, Tuple
+from typing import List, Set, Union, Dict, Collection, Tuple, Sequence
 
 import pytest
 
@@ -269,3 +269,23 @@ def test_from_dict_with_tuple_and_implicit_any_types():
     result = from_dict(X, {"t": (1, 2, 3)})
 
     assert result == X(t=(1, 2, 3))
+
+
+def test_from_dict_with_sequence_and_tuple():
+    @dataclass
+    class X:
+        s: Sequence[int]
+
+    result = from_dict(X, {'s': (1, 2, 3)})
+
+    assert result == X(s=(1, 2, 3))
+
+
+def test_from_dict_with_sequence_and_empty_tuple():
+    @dataclass
+    class X:
+        s: Sequence[int]
+
+    result = from_dict(X, {'s': ()})
+
+    assert result == X(s=())

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -276,7 +276,7 @@ def test_from_dict_with_sequence_and_tuple():
     class X:
         s: Sequence[int]
 
-    result = from_dict(X, {'s': (1, 2, 3)})
+    result = from_dict(X, {"s": (1, 2, 3)})
 
     assert result == X(s=(1, 2, 3))
 
@@ -286,6 +286,6 @@ def test_from_dict_with_sequence_and_empty_tuple():
     class X:
         s: Sequence[int]
 
-    result = from_dict(X, {'s': ()})
+    result = from_dict(X, {"s": ()})
 
     assert result == X(s=())

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -215,3 +215,12 @@ def test_from_dict_with_strict_unions_match_and_single_match():
     result = from_dict(Z, data, Config(strict_unions_match=True))
 
     assert result == Z(u=Y(f=1))
+
+
+def test_from_dict_with_allow_missing_fields_with_none():
+    @dataclass
+    class X:
+        a: int
+        b: str
+
+    assert X(a=1, b=None) == from_dict(X, {"a": 1}, Config(allow_missing_fields_as_none=True))

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, InitVar
 from datetime import date
 from enum import Enum
 from typing import Optional, List, Union
@@ -98,6 +98,33 @@ def test_from_dict_with_type_hooks_and_generic_sequence():
     result = from_dict(X, {"c": ["TEST"]}, config=Config(type_hooks={str: str.lower}))
 
     assert result == X(c=["test"])
+
+
+def test_from_dict_with_type_hooks_and_init_vars():
+    @dataclass
+    class X:
+        name: str
+        value: int
+
+    def x_factory(tuple):
+        class_map = {"X": X}
+        return from_dict(data_class=class_map[tuple[0]], data=tuple[1])
+
+    @dataclass
+    class MyDictContainer:
+        name: str
+        var: InitVar[X]
+
+        def __post_init__(self, var: X):
+            self.name += var.name
+
+    data = {
+        "name": "test",
+        "var": ("X", {"name": "_VARS_NAME", "value": 1}),
+    }
+
+    d = from_dict(data_class=MyDictContainer, data=data, config=Config(type_hooks={X: x_factory}))
+    assert d.name == "test_VARS_NAME"
 
 
 def test_from_dict_with_type_hook_exception():

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,3 +1,4 @@
+from collections.abc import MutableMapping
 from dataclasses import dataclass, InitVar
 from datetime import date
 from enum import Enum
@@ -12,6 +13,39 @@ from dacite import (
     UnexpectedDataError,
     StrictUnionMatchError,
 )
+
+
+class TypeHooksMapping(MutableMapping):
+    """
+    Simple mapping implementation which lets us test that Config.type_hooks may
+    be a Mapping, which is more general than the typical use case of being a
+    Dict.
+    """
+    def __init__(self, *args, **kwargs):
+        self.__dict__.update(*args, **kwargs)
+
+    def __getitem__(self, key):
+        if key in self.__dict__:
+            # If a type hook has been specified, use it.
+            return self.__dict__[key]
+        else:
+            # Otherwise, use a dummy type hook which always constructs a 1.
+            return lambda _: 1
+
+    def __setitem__(self, key, value):
+        self.__dict__[key] = value
+
+    def __delitem__(self):
+        if key in self.__dict__:
+            del self.__dict__[key]
+        else:
+            raise IndexError
+
+    def __len__(self):
+        return len(self.__dict__)
+
+    def __iter__(self):
+        return iter(self.__dict__)
 
 
 def test_from_dict_with_type_hooks():
@@ -42,6 +76,21 @@ def test_from_dict_with_type_hooks_and_union():
     result = from_dict(X, {"s": "TEST"}, Config(type_hooks={str: str.lower}))
 
     assert result == X(s="test")
+
+
+def test_type_hook_mapping():
+    @dataclass
+    class X:
+        s: str
+        i: int
+
+    result = from_dict(
+        X,
+        {"s": "TEST", "i": 0},
+        Config(type_hooks=TypeHooksMapping({str: str.lower}))
+    )
+
+    assert result == X(s="test", i=1)
 
 
 def test_from_dict_with_generic_type_hooks():

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -21,6 +21,7 @@ class TypeHooksMapping(MutableMapping):
     be a Mapping, which is more general than the typical use case of being a
     Dict.
     """
+
     def __init__(self, *args, **kwargs):
         self.__dict__.update(*args, **kwargs)
 
@@ -108,16 +109,16 @@ def test_from_dict_with_generic_list_type_hooks():
     class X:
         l: List[int]
 
-    result = from_dict(X, {"l": [3,1,2]}, Config(type_hooks={List: sorted}))
+    result = from_dict(X, {"l": [3, 1, 2]}, Config(type_hooks={List: sorted}))
 
-    assert result == X(l=[1,2,3])
+    assert result == X(l=[1, 2, 3])
 
 
 def test_from_dict_with_generic_dict_type_hooks():
     @dataclass
     class X:
         d: Dict[str, int]
-    
+
     def add_b(value):
         value["b"] = 2
         return value
@@ -125,6 +126,17 @@ def test_from_dict_with_generic_dict_type_hooks():
     result = from_dict(X, {"d": {"a": 1}}, Config(type_hooks={Dict: add_b}))
 
     assert result == X(d={"a": 1, "b": 2})
+
+
+def test_type_hook_mapping():
+    @dataclass
+    class X:
+        s: str
+        i: int
+
+    result = from_dict(X, {"s": "TEST", "i": 0}, Config(type_hooks=TypeHooksMapping({str: str.lower})))
+
+    assert result == X(s="test", i=1)
 
 
 def test_from_dict_with_cast():

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, InitVar
 from datetime import date
 from enum import Enum
-from typing import Optional, List, Union
+from typing import Any, Dict, Optional, List, Union
 
 import pytest
 
@@ -42,6 +42,40 @@ def test_from_dict_with_type_hooks_and_union():
     result = from_dict(X, {"s": "TEST"}, Config(type_hooks={str: str.lower}))
 
     assert result == X(s="test")
+
+
+def test_from_dict_with_generic_type_hooks():
+    @dataclass
+    class X:
+        s: str
+
+    result = from_dict(X, {"s": "TEST"}, Config(type_hooks={Any: str.lower}))
+
+    assert result == X(s="test")
+
+
+def test_from_dict_with_generic_list_type_hooks():
+    @dataclass
+    class X:
+        l: List[int]
+
+    result = from_dict(X, {"l": [3,1,2]}, Config(type_hooks={List: sorted}))
+
+    assert result == X(l=[1,2,3])
+
+
+def test_from_dict_with_generic_dict_type_hooks():
+    @dataclass
+    class X:
+        d: Dict[str, int]
+    
+    def add_b(value):
+        value["b"] = 2
+        return value
+
+    result = from_dict(X, {"d": {"a": 1}}, Config(type_hooks={Dict: add_b}))
+
+    assert result == X(d={"a": 1, "b": 2})
 
 
 def test_from_dict_with_cast():

--- a/tests/core/test_frozen_non_init_var.py
+++ b/tests/core/test_frozen_non_init_var.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass, field
+
+from dacite import from_dict
+
+
+def test_from_dict_with_frozen_non_init_var_with_default():
+    @dataclass(frozen=True)
+    class X:
+        a: int = field(init=False, default=5)
+
+    result = from_dict(X, {})
+
+    assert result.a == 5

--- a/tests/core/test_ndarray.py
+++ b/tests/core/test_ndarray.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import Sequence, TypeVar
+
+import numpy
+import numpy.typing
+import numpy.testing
+
+from dacite import from_dict, Config
+from tests.common import ndarray_support
+
+
+@ndarray_support
+def test_from_dict_with_ndarray():
+    @dataclass
+    class X:
+        a: numpy.ndarray
+
+    result = from_dict(X, {"a": numpy.array([1, 2, 3])})
+
+    numpy.testing.assert_allclose(result.a, numpy.array([1, 2, 3]))
+
+
+@ndarray_support
+def test_from_dict_with_nptndarray():
+    @dataclass
+    class X:
+        a: numpy.typing.NDArray[numpy.float64]
+
+    result = from_dict(X, {"a": numpy.array([1, 2, 3])})
+
+    numpy.testing.assert_allclose(result.a, numpy.array([1, 2, 3]))
+
+
+@ndarray_support
+def test_from_dict_with_nptndarray_and_converter():
+    @dataclass
+    class X:
+        a: numpy.typing.NDArray[numpy.float64]
+
+    D = TypeVar("D", bound=numpy.generic)
+
+    def coerce_to_array(s: Sequence[D]) -> numpy.typing.NDArray[D]:
+        return numpy.array(s)
+
+    result = from_dict(X, {"a": [1, 2, 3]}, Config(type_hooks={numpy.typing.NDArray[numpy.float64]: coerce_to_array}))
+
+    numpy.testing.assert_allclose(result.a, numpy.array([1, 2, 3]))

--- a/tests/core/test_ndarray.py
+++ b/tests/core/test_ndarray.py
@@ -1,9 +1,13 @@
 from dataclasses import dataclass
 from typing import Sequence, TypeVar
+import pytest
 
-import numpy
-import numpy.typing
-import numpy.testing
+try:
+    import numpy
+    import numpy.typing
+    import numpy.testing
+except ImportError:
+    pytest.skip("numpy not available", allow_module_level=True)
 
 from dacite import from_dict, Config
 from tests.common import ndarray_support

--- a/tests/localns/localns_a.py
+++ b/tests/localns/localns_a.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List
+
+from dacite import from_dict, Config
+
+if TYPE_CHECKING:
+    from .localns_b import BB
+
+
+@dataclass
+class AA:
+    bb_list: List[BB]
+
+    @classmethod
+    def shared_function(cls):
+        return "X"
+
+    @classmethod
+    def config(cls, h_aa):
+        from .localns_b import BB
+
+        config = Config(
+            forward_references={
+                "BB": BB,
+            }
+        )
+        aa: AA = from_dict(cls, h_aa, config=config)
+        return aa

--- a/tests/localns/localns_b.py
+++ b/tests/localns/localns_b.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+from .localns_a import AA  # would like to keep AA import as global
+
+
+@dataclass
+class BB:
+    name: str
+
+    @classmethod
+    def shared_function(cls):
+        AA.shared_function()  # need to use AA in multiple places of bb.py
+
+    @classmethod
+    def config(
+        cls,
+    ):
+        return {"x": "y"}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -23,7 +23,12 @@ from dacite.types import (
     is_set,
     is_tuple,
 )
-from tests.common import literal_support, init_var_type_support, type_hints_with_generic_collections_support, pep_604_support
+from tests.common import (
+    literal_support,
+    init_var_type_support,
+    pep_604_support,
+    type_hints_with_generic_collections_support,
+)
 
 
 def test_is_union_with_union():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -474,6 +474,7 @@ def test_is_set_union():
     assert not is_set(Union[int, float])
 
 
+@init_var_type_support
 def test_get_type_hint_for_init_var():
     @dataclass
     class X:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -21,7 +21,7 @@ from dacite.types import (
     is_type_generic,
     is_set,
 )
-from tests.common import literal_support, init_var_type_support
+from tests.common import literal_support, init_var_type_support, pep_604_support
 
 
 def test_is_union_with_union():
@@ -30,6 +30,11 @@ def test_is_union_with_union():
 
 def test_is_union_with_non_union():
     assert not is_union(int)
+
+
+@pep_604_support
+def test_is_union_with_pep_604_union():
+    assert is_union(int | float)
 
 
 @literal_support
@@ -61,6 +66,16 @@ def test_is_optional_with_non_optional():
 
 def test_is_optional_with_optional_of_union():
     assert is_optional(Optional[Union[int, float]])
+
+
+@pep_604_support
+def test_is_optional_with_pep_604_union():
+    assert is_optional(int | float | None)
+
+
+@pep_604_support
+def test_is_optional_with_non_optional_pep_604_union():
+    assert not is_optional(int | float)
 
 
 def test_extract_optional():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -21,8 +21,9 @@ from dacite.types import (
     get_data_class_hints,
     is_type_generic,
     is_set,
+    is_tuple,
 )
-from tests.common import literal_support, init_var_type_support, pep_604_support
+from tests.common import literal_support, init_var_type_support, type_hints_with_generic_collections_support, pep_604_support
 
 
 def test_is_union_with_union():
@@ -36,6 +37,36 @@ def test_is_union_with_non_union():
 @pep_604_support
 def test_is_union_with_pep_604_union():
     assert is_union(int | float)
+
+
+def test_is_tuple_with_tuple():
+    assert is_tuple(Tuple[int, float, str])
+
+
+def test_is_tuple_with_variable_length_tuple():
+    assert is_tuple(Tuple[int, ...])
+
+
+def test_is_tuple_with_not_parametrized_tuple():
+    assert is_tuple(Tuple)
+
+
+def test_is_tuple_with_tuple_class_object():
+    assert is_tuple(tuple)
+
+
+@type_hints_with_generic_collections_support
+def test_is_tuple_with_tuple_generic():
+    assert is_tuple(tuple[int, float, str])
+
+
+@type_hints_with_generic_collections_support
+def test_is_tuple_with_variable_length_tuple_generic():
+    assert is_tuple(tuple[int, ...])
+
+
+def test_is_tuple_with_non_tuple():
+    assert not is_tuple(int)
 
 
 @literal_support

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -264,7 +264,7 @@ def test_is_instance_with_not_supported_generic_types():
     class X(Generic[T]):
         pass
 
-    assert not is_instance(X[str](), X[str])
+    assert is_instance(X[str](), X[str])
 
 
 def test_is_instance_with_generic_mapping_and_matching_value_type():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -87,6 +87,10 @@ def test_extract_optional_with_wrong_type():
         extract_optional(List[None])
 
 
+def test_extract_optional_with_optional_of_union():
+    assert extract_optional(Optional[Union[int, str]]) == Union[int, str]
+
+
 def test_is_generic_with_generic():
     assert is_generic(Optional[int])
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,4 @@
-from dataclasses import InitVar
+from dataclasses import dataclass, InitVar
 from typing import Optional, Union, List, Any, Dict, NewType, TypeVar, Generic, Collection, Tuple, Type
 
 import pytest
@@ -18,6 +18,7 @@ from dacite.types import (
     is_literal,
     is_init_var,
     extract_init_var,
+    get_data_class_hints,
     is_type_generic,
     is_set,
 )
@@ -435,3 +436,12 @@ def test_is_set_int_class():
 
 def test_is_set_union():
     assert not is_set(Union[int, float])
+
+
+def test_get_type_hint_for_init_var():
+    @dataclass
+    class X:
+        name: str
+        value: InitVar[int]
+
+    assert get_data_class_hints(X) == {"name": str, "value": int}


### PR DESCRIPTION
Hi @yerihyo

Re:
https://github.com/konradhalas/dacite/issues/129
https://github.com/konradhalas/dacite/pull/128

I was trying to understand you issue but not fully got it, I added your examples and your PR (I think you wanted to change `globalns` to `localns` in a few more places, so I did)

If you want to merge this, please add a test that passes only after this fix.
